### PR TITLE
Fix the build status icon in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Create a git repository from Fastly service generated VCL.
 
 [![Build
-Status](https://travis-ci.org/fastly/fastly2git.svg?branch=master](https://travis-ci.org/fastly/fastly2git/)
+Status](https://travis-ci.org/fastly/fastly2git.svg?branch=master)](https://travis-ci.org/fastly/fastly2git/)
 
 # Screencast
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Create a git repository from Fastly service generated VCL.
 
 [![Build
-Status](https://magnum.travis-ci.com/fastly/fastly2git.svg?token=cko3qJRV7zLNRYQi8Qpq&branch=master)](https://magnum.travis-ci.com/fastly/fastly2git)
+Status](https://travis-ci.org/fastly/fastly2git.svg?branch=master](https://travis-ci.org/fastly/fastly2git/)
 
 # Screencast
 


### PR DESCRIPTION
Now that the repository is open source, fix the build status icon in the
readme to point to the public Travis CI URLs